### PR TITLE
fileType: "pdf" being added when no fileType is requested

### DIFF
--- a/lib/google-search.js
+++ b/lib/google-search.js
@@ -28,7 +28,7 @@ var GoogleSearch = function(options) {
 
 GoogleSearch.prototype.build = function(options, callback) {
   options = _.defaults(options, {
-    fileType: "pdf"
+ 
   });
   //this._doRequest(this._generateUrl(options), callback); 
   this._generateUrl(options);


### PR DESCRIPTION
The fileType is an optional parameter and it's being added no matter what. 
